### PR TITLE
Update openapi.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,4 +1,3 @@
-
 openapi: 3.0.3
 info:
   title: API for International Registry Interoperability (Work In Progress)
@@ -486,104 +485,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Errors'
-
-
-  /action/{regId}/registerCooperativeApproachAuth:
-    post:
-      tags:
-        - Action
-      operationId: registerCooperativeApproachAuth
-      summary: Register authorised cooperative approach, from the registry identified by regId.
-      description: Register authorised cooperative approach, from the registry identified by regId.
-        This may be performed by the secretariat when it registers the CA with the CARP.
-        This enables the CAs and ITMOs for interoperability.
-        This will create the CooperativeApproachAuthorisation and the CooperativeApproach within the International Registry.
-      parameters:
-        - name: regId
-          in: path
-          description: The registry identifier of the participating Party registry section in which the contact is to be inserted.
-          required: true
-          schema:
-            type: string
-            pattern: '^[A-Z]{3}\d{2}$'
-            example: DEU00
-      requestBody:
-        description: The cooperative approach authorisation to be registered.
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CooperativeApproachAuthorization'
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                type: integer
-        '400':
-          description: Unsuccessful operation
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-        default:
-          description: Unexpected error
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-
-
-  /action/{regId}/registerITMOs:
-    post:
-      tags:
-        - Action
-      operationId: registerITMOs
-      summary: Register authorised ITMOs, from the registry identified by regId.
-      description: Register authorised ITMOs, from the registry identified by regId.
-        This enables ITMOs for interoperability by registering the ITMO's unique identifier and accountId.
-        If the accountId does not exist in the registry, the account is added to the registry.
-        If the ITMOs's unique identifier (Party Id, serialFist, serialLast) overlaps with another ITMO block,
-        the operation fails.
-        If the ITMO's cooperative approach is not found, or is not yet authorised, the operation fails.
-        If the ITMO's details contradict those provided when the ITMO or its Cooperative Approach were authorised, the operation fails.
-      parameters:
-        - name: regId
-          in: path
-          description: The registry identifier of the participating Party registry section in which the contact is to be inserted.
-          required: true
-          schema:
-            type: string
-            pattern: '^[A-Z]{3}\d{2}$'
-            example: DEU00
-      requestBody:
-        description: The ITMOs to be registered.
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ITMO'
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                type: integer
-        '400':
-          description: Unsuccessful operation
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-        default:
-          description: Unexpected error
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Errors'
-
 
   /action/{regId}/propose:
     post:


### PR DESCRIPTION
Remove the registerCooperative Approach and remove ITMO operations:

The registration (ie, authorization) occurs in the CARP, where they get an authorization ID.

An ITMO should refer to this authorization Id.